### PR TITLE
feat(export): make the Export folder user-configurable (issue #24)

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1775,7 +1775,7 @@ export const en: TranslationKeys = {
             },
             manuscriptOutputFolder: {
                 name: 'Export folder',
-                desc: 'Manuscript, outline, and cue card exports (Markdown, PDF, beat sheets, index cards).',
+                desc: 'Destination for manuscript, outline, and cue card exports (Markdown, PDF, beat sheets, index cards). Must be a folder inside your vault.',
                 placeholder: 'Radial Timeline/Export',
             },
             outlineOutputFolder: {

--- a/src/settings/sections/ConfigurationSection.ts
+++ b/src/settings/sections/ConfigurationSection.ts
@@ -1,10 +1,13 @@
-import { App, Setting as Settings } from 'obsidian';
+import { App, Setting as Settings, normalizePath } from 'obsidian';
 import type { TextComponent } from 'obsidian';
 import type RadialTimelinePlugin from '../../main';
 import { clearFontMetricsCaches } from '../../renderer/utils/FontMetricsCache';
 import { t } from '../../i18n';
 import { addHeadingIcon, addWikiLink, applyErtHeaderLayout } from '../wikiLink';
 import { addPathChip } from '../pathChip';
+import { ModalFolderSuggest } from '../FolderSuggest';
+import { DEFAULT_SETTINGS } from '../defaults';
+import { resolveExportOutputFolder, escapesVaultRoot } from '../../utils/aiOutput';
 import { ERT_CLASSES } from '../../ui/classes';
 import { IMPACT_FULL } from '../SettingImpact';
 import { countContentLogFiles, resolveLogsRoot } from '../../ai/log';
@@ -54,7 +57,7 @@ export function renderConfigurationSection(params: { app: App; plugin: RadialTim
     logsContainer.createDiv({ cls: 'ert-config-group-title', text: 'Logs' });
 
     const outputFolder = resolveLogsRoot();
-    const exportFolder = plugin.settings.manuscriptOutputFolder || 'Radial Timeline/Export';
+    const exportFolderDefault = DEFAULT_SETTINGS.manuscriptOutputFolder || 'Radial Timeline/Export';
 
     // Logs
     const logsRow = createDenseRow(logsContainer, {
@@ -64,14 +67,65 @@ export function renderConfigurationSection(params: { app: App; plugin: RadialTim
     });
     addPathChip(logsRow, app, outputFolder);
 
-    // Export folder is no longer user-configurable — shown here as an
-    // informational readout so users know where exports land.
+    // Export folder is user-configurable. Manuscript, outline, and cue-card
+    // exports land here. Writes go through the vault API, so the value must
+    // stay inside the vault (validated on commit). The reveal chip mirrors
+    // the live value so users can jump to the folder in the file explorer.
     const exportRow = createDenseRow(logsContainer, {
         title: t('settings.configuration.manuscriptOutputFolder.name'),
         description: t('settings.configuration.manuscriptOutputFolder.desc'),
-        control: () => {}
+        control: (setting) => {
+            setting.addText(text => {
+                const inputEl = text.inputEl;
+                text.setPlaceholder(exportFolderDefault);
+                text.setValue(plugin.settings.manuscriptOutputFolder || '');
+                inputEl.addClass('ert-input');
+
+                const resetState = () => {
+                    inputEl.removeClass('ert-setting-input-success');
+                    inputEl.removeClass('ert-setting-input-error');
+                };
+                const flashError = () => {
+                    inputEl.addClass('ert-setting-input-error');
+                    window.setTimeout(() => inputEl.removeClass('ert-setting-input-error'), 2000);
+                };
+                const commit = async (raw: string) => {
+                    resetState();
+                    const trimmed = raw.trim();
+                    const normalized = trimmed ? normalizePath(trimmed) : '';
+                    if (normalized && escapesVaultRoot(normalized)) {
+                        flashError();
+                        return;
+                    }
+                    const nextFolder = normalized || exportFolderDefault;
+                    plugin.settings.manuscriptOutputFolder = nextFolder;
+                    // Outline exports share the destination; keep the legacy
+                    // field in sync so a stale value can't diverge.
+                    plugin.settings.outlineOutputFolder = nextFolder;
+                    await plugin.saveSettings();
+                    text.setValue(normalized);
+                    refreshExportChip(resolveExportOutputFolder(plugin));
+                    inputEl.addClass('ert-setting-input-success');
+                    window.setTimeout(() => inputEl.removeClass('ert-setting-input-success'), 1000);
+                };
+
+                new ModalFolderSuggest(app, inputEl, (path) => { void commit(path); });
+                plugin.registerDomEvent(inputEl, 'blur', () => { void commit(text.getValue()); });
+                plugin.registerDomEvent(inputEl, 'keydown', (evt: KeyboardEvent) => {
+                    if (evt.key === 'Enter') {
+                        evt.preventDefault();
+                        inputEl.blur();
+                    }
+                });
+            });
+        }
     });
-    addPathChip(exportRow, app, exportFolder);
+    const refreshExportChip = (folder: string): void => {
+        const existing = exportRow.controlEl.querySelector<HTMLElement>(':scope > .ert-path-chips');
+        if (existing) existing.remove();
+        addPathChip(exportRow, app, folder);
+    };
+    refreshExportChip(resolveExportOutputFolder(plugin));
 
     const apiLoggingSetting = createDenseRow(logsContainer, {
         title: 'Enable AI content logs',

--- a/src/utils/aiOutput.test.ts
+++ b/src/utils/aiOutput.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { escapesVaultRoot, resolveExportOutputFolder } from './aiOutput';
+import { DEFAULT_SETTINGS } from '../settings/defaults';
+import type RadialTimelinePlugin from '../main';
+
+const DEFAULT_EXPORT = DEFAULT_SETTINGS.manuscriptOutputFolder || 'Radial Timeline/Export';
+
+function pluginWithFolder(value: string | undefined): RadialTimelinePlugin {
+    return { settings: { manuscriptOutputFolder: value } } as unknown as RadialTimelinePlugin;
+}
+
+describe('escapesVaultRoot', () => {
+    it('accepts vault-relative folders', () => {
+        for (const ok of ['Radial Timeline/Export', 'Exports', 'a/b/c', 'Manuscripts/Final']) {
+            expect(escapesVaultRoot(ok)).toBe(false);
+        }
+    });
+
+    it('rejects empty, drive-letter, and parent-escaping paths', () => {
+        for (const bad of ['', 'G:/Drive', 'C:/Users/me', '..', '../outside', 'a/../../b']) {
+            expect(escapesVaultRoot(bad)).toBe(true);
+        }
+    });
+});
+
+describe('resolveExportOutputFolder', () => {
+    it('falls back to the default when unset or blank', () => {
+        expect(resolveExportOutputFolder(pluginWithFolder(undefined))).toBe(DEFAULT_EXPORT);
+        expect(resolveExportOutputFolder(pluginWithFolder('   '))).toBe(DEFAULT_EXPORT);
+    });
+
+    it('honors a configured vault-relative folder (normalized)', () => {
+        expect(resolveExportOutputFolder(pluginWithFolder('My Exports'))).toBe('My Exports');
+        expect(resolveExportOutputFolder(pluginWithFolder('a//b/'))).toBe('a/b');
+        // A leading slash is vault-root-relative; normalizePath strips it.
+        expect(resolveExportOutputFolder(pluginWithFolder('/absolute'))).toBe('absolute');
+    });
+
+    it('falls back to the default for folders that escape the vault', () => {
+        expect(resolveExportOutputFolder(pluginWithFolder('G:\\Drive'))).toBe(DEFAULT_EXPORT);
+        expect(resolveExportOutputFolder(pluginWithFolder('../escape'))).toBe(DEFAULT_EXPORT);
+        expect(resolveExportOutputFolder(pluginWithFolder('a/../../b'))).toBe(DEFAULT_EXPORT);
+    });
+});

--- a/src/utils/aiOutput.ts
+++ b/src/utils/aiOutput.ts
@@ -40,10 +40,30 @@ export async function ensureOutlineOutputFolder(plugin: RadialTimelinePlugin): P
 }
 
 export function resolveExportOutputFolder(plugin: RadialTimelinePlugin): string {
-    // Export folder is no longer user-configurable (same treatment as the
-    // AI logs folder). All manuscript, outline, and cue-card exports land in
-    // the canonical vault location. Legacy `settings.manuscriptOutputFolder`
-    // values are ignored.
-    void plugin;
-    return normalizePath(DEFAULT_SETTINGS.manuscriptOutputFolder || 'Radial Timeline/Export');
+    // User-configurable destination for manuscript, outline, and cue-card
+    // exports. Exports are written through the Obsidian vault API, so the
+    // folder must stay inside the vault: an absolute path or a value that
+    // escapes the vault root falls back to the canonical default.
+    const fallback = normalizePath(DEFAULT_SETTINGS.manuscriptOutputFolder || 'Radial Timeline/Export');
+    const configured = (plugin.settings.manuscriptOutputFolder || '').trim();
+    if (!configured) return fallback;
+    const normalized = normalizePath(configured);
+    if (escapesVaultRoot(normalized)) return fallback;
+    return normalized;
+}
+
+/**
+ * True when a normalized vault-relative path is absolute (POSIX `/...` or a
+ * Windows drive letter like `G:/...`) or climbs above the vault root (`..`).
+ * Exports are written through the vault API, so such targets are rejected.
+ * Note: Obsidian's `normalizePath` strips leading slashes, so the drive-letter
+ * and `..` checks do the real work for hand-entered absolute paths.
+ */
+export function escapesVaultRoot(normalizedPath: string): boolean {
+    return !normalizedPath
+        || normalizedPath.startsWith('/')
+        || /^[A-Za-z]:/.test(normalizedPath)
+        || normalizedPath === '..'
+        || normalizedPath.startsWith('../')
+        || normalizedPath.includes('/../');
 }

--- a/wiki/Publishing.md
+++ b/wiki/Publishing.md
@@ -235,7 +235,7 @@ The exporter:
 4. Emits scene prose separated by ornaments inside each chapter.
 5. Hands the assembled markdown to Pandoc, which produces a PDF.
 
-Output goes to `Radial Timeline/Export/` by default. The export destination is shown in **Settings → Advanced → Configuration**.
+Output always goes to `Radial Timeline/Export/` inside your vault. This location is fixed and not configurable; the read-only path shown in **Settings → Advanced → Configuration → Export folder** is informational only — clicking it reveals the folder in Obsidian's file explorer. To keep exports elsewhere (for example a Google Drive folder), point a sync/symlink at `Radial Timeline/Export/`, or copy the generated files out after exporting.
 
 ### Minimum viable Signature manuscript
 
@@ -276,7 +276,7 @@ The export panel lets you:
 - Review export checks for missing templates, missing fonts, template compatibility, and layout-specific warnings
 - Preview the selected layout's page structure before generating a PDF
 
-Files land in `Radial Timeline/Export/` unless you've set a custom export folder.
+Files land in `Radial Timeline/Export/` inside your vault. This destination is fixed and not user-configurable.
 
 For the end-to-end export workflow and troubleshooting, start here and use the checks in the export panel to catch missing Pandoc, LaTeX, templates, or fonts before rendering.
 

--- a/wiki/Publishing.md
+++ b/wiki/Publishing.md
@@ -235,7 +235,7 @@ The exporter:
 4. Emits scene prose separated by ornaments inside each chapter.
 5. Hands the assembled markdown to Pandoc, which produces a PDF.
 
-Output always goes to `Radial Timeline/Export/` inside your vault. This location is fixed and not configurable; the read-only path shown in **Settings → Advanced → Configuration → Export folder** is informational only — clicking it reveals the folder in Obsidian's file explorer. To keep exports elsewhere (for example a Google Drive folder), point a sync/symlink at `Radial Timeline/Export/`, or copy the generated files out after exporting.
+Output goes to `Radial Timeline/Export/` by default. You can change the destination in **Settings → Advanced → Configuration → Export folder** — type or pick any folder inside your vault, and the chip beside the field reveals it in Obsidian's file explorer. Because exports are written through the vault, the folder must live inside the vault; to keep exports on an external drive (for example a Google Drive folder), point a sync/symlink at your chosen Export folder, or copy the generated files out after exporting.
 
 ### Minimum viable Signature manuscript
 
@@ -276,7 +276,7 @@ The export panel lets you:
 - Review export checks for missing templates, missing fonts, template compatibility, and layout-specific warnings
 - Preview the selected layout's page structure before generating a PDF
 
-Files land in `Radial Timeline/Export/` inside your vault. This destination is fixed and not user-configurable.
+Files land in `Radial Timeline/Export/` by default, or in whatever vault folder you set under **Settings → Advanced → Configuration → Export folder**.
 
 For the end-to-end export workflow and troubleshooting, start here and use the checks in the export panel to catch missing Pandoc, LaTeX, templates, or fonts before rendering.
 

--- a/wiki/Settings-Advanced.md
+++ b/wiki/Settings-Advanced.md
@@ -24,5 +24,5 @@ Advanced is currently grouped into three areas:
 ### Logs
 
 *   **AI output folder**: Readout of the main RT logs location.
-*   **Export folder**: Readout of the manuscript/export destination.
+*   **Export folder**: Destination for manuscript, outline, and cue-card exports. Editable — type or pick any folder inside your vault; the chip beside the field reveals it in the file explorer.
 *   **Enable AI content logs**: When enabled, full prompts, materials, and API responses are written as content logs.


### PR DESCRIPTION
## Summary

Resolves #24. The Export folder destination was hardcoded to `Radial Timeline/Export` and the Settings chip was a read-only readout, so editing `manuscriptOutputFolder` (in `data.json` or anywhere) had no effect — the reported "can't change the Export folder" behavior.

This implements **Tier A**: a single, redefinable, vault-relative Export folder. (Multiple destinations and external/outside-vault paths like `G:\` were evaluated and deliberately left out of scope — see the discussion on the issue.)

## Changes

- **`src/utils/aiOutput.ts`** — `resolveExportOutputFolder` now honors `settings.manuscriptOutputFolder`. New `escapesVaultRoot` guard: absolute paths, Windows drive-letters (`G:/…`), and `../` escapes fall back to the canonical default, because exports are written through the Obsidian vault API and must stay inside the vault.
- **`src/settings/sections/ConfigurationSection.ts`** — the Export folder row is now an editable text input with folder autocomplete (`ModalFolderSuggest`), Enter/blur commit, success/error validation feedback, and a live reveal chip that tracks the saved value. Outline export's legacy folder field is kept in sync with the shared destination. Listeners use `plugin.registerDomEvent` (managed cleanup).
- **`src/i18n/locales/en.ts`** — setting description updated to reflect configurability + the in-vault constraint.
- **`wiki/Publishing.md`, `wiki/Settings-Advanced.md`** — document the configurable folder and the symlink/sync workaround for keeping exports on an external drive.
- **`src/utils/aiOutput.test.ts`** — unit tests for `escapesVaultRoot` and `resolveExportOutputFolder`.

## Verification

- `tsc --noEmit` clean; new tests pass.
- Full `npm run gates` suite green (all 14, including code-quality, compliance vs baseline, and unit tests).

## Notes

Writes still stay inside the vault by design. Reaching an external drive (the issue author's `G:\` goal) needs either the symlink/sync workaround (now documented) or a larger external-path feature (Tier C), which is a separate decision.

https://claude.ai/code/session_01WqE88qh8rSejRhFDsceMWr