### PR TITLE
Add SessionStart hook to prepare remote checkouts

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Prepares a fresh (remote) checkout so `npm run gates` can pass:
+#   - installs pinned dependencies (incl. the TypeScript version in package.json)
+#   - generates the gitignored styles.css build artifact the CSS gate reads
+# Without this, a fresh clone fails gates on a missing styles.css and a
+# mismatched TypeScript, which the Stop-hook gate then loops on.
+set -euo pipefail
+
+# Only needed in remote/cloud environments; a local checkout already has these.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-.}"
+npm install
+node scripts/bundle-css.mjs

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",


### PR DESCRIPTION
## Problem

Fresh remote checkouts (Claude Code on the web) start with **no `node_modules`** and **no generated `styles.css`**. As a result:

- `npx tsc` resolves the latest TypeScript from the network instead of the version pinned in `package.json`, and rejects the project's `tsconfig` options.
- The gitignored `styles.css` build artifact is missing, so the CSS-duplicates gate errors with `ENOENT`.

`npm run gates` therefore fails. Because the existing **Stop hook** runs the gates with `asyncRewake: true`, each failure re-wakes the session — producing an inescapable loop of "GATES FAILED" notifications that no code change can clear, since the failure is environmental, not a code defect.

## Fix

Add a **SessionStart hook** (`.claude/hooks/session-start.sh`, registered in `.claude/settings.json`) that runs **in remote environments only** and:

1. `npm install` — installs pinned dependencies, including the correct TypeScript version.
2. `node scripts/bundle-css.mjs` — regenerates the `styles.css` artifact the CSS gate reads.

With the environment prepared before the first Stop event, the gates have valid inputs and pass, so the Stop hook exits cleanly and never loops. Local checkouts are unaffected (the hook no-ops when `CLAUDE_CODE_REMOTE != true`).

## Validation

- `.claude/settings.json` parses as valid JSON with both `SessionStart` and the existing `Stop` hook.
- Ran the hook with `CLAUDE_CODE_REMOTE=true`: installs deps, regenerates `styles.css`.
- Confirmed local TypeScript resolves to the pinned version afterward.
- `npm run gates` → **all 13 gates pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAd5svXQQ2vVDMPQ7JP327

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAd5svXQQ2vVDMPQ7JP327)_