### PR TITLE
Fix Narrative Mode act wraparound (#31) and font-install false success (#29)

### DIFF
--- a/src/renderer/TimelineRenderer.ts
+++ b/src/renderer/TimelineRenderer.ts
@@ -536,9 +536,14 @@ export function createTimelineSVG(
         const sortByWhen = isChronologueMode ? true : (settings.sortByWhenDate ?? false);
 
         const sceneActNumber = scene.actNumber !== undefined ? scene.actNumber : 1;
-        const actIndex = sortByWhen
+        const rawActIndex = sortByWhen
             ? 0
             : (isSagaScope ? (typeof scene.bookIndex === 'number' ? scene.bookIndex : 0) : (sceneActNumber - 1));
+        // Clamp to the nearest valid quadrant so this lookup agrees with how
+        // Precompute.ts bucketed the scene — an unclamped index here would
+        // miss the scene (empty lookup, sceneIndex -1) and re-derive a
+        // wrapped-around angle instead of reusing the clamped bucket.
+        const actIndex = Math.min(Math.max(rawActIndex, 0), numActs - 1);
         const scenesInActAndSubplot = (scenesByActAndSubplot[actIndex] && scenesByActAndSubplot[actIndex][subplot]) || [];
 
         // Never generate inner-ring synopses for Plot notes here

--- a/src/renderer/components/NumberSquares.ts
+++ b/src/renderer/components/NumberSquares.ts
@@ -94,9 +94,13 @@ export function renderNumberSquaresUnified(params: {
 
       const sceneActNumber = scene.actNumber !== undefined ? scene.actNumber : 1;
       // When using When date sorting, all scenes are in act 0
-      const actIndex = sortByWhen
+      const rawActIndex = sortByWhen
         ? 0
         : (isSagaScope ? (typeof scene.bookIndex === 'number' ? scene.bookIndex : 0) : (sceneActNumber - 1));
+      // Clamp to the nearest valid quadrant so this lookup agrees with how
+      // Precompute.ts bucketed the scene — an unclamped index here would
+      // miss the scene (empty lookup) and re-derive a wrapped-around angle.
+      const actIndex = Math.min(Math.max(rawActIndex, 0), totalActs - 1);
 
       const scenesInActAndSubplot = (scenesByActAndSubplot[actIndex] && scenesByActAndSubplot[actIndex][subplot]) || [];
       const filteredScenes = scenesInActAndSubplot.filter(s => !isBeatNote(s));
@@ -257,9 +261,11 @@ export function renderInnerRingsNumberSquaresAllScenes(params: {
     // When using When date sorting, all scenes are in act 0
     // When using manuscript order, use the scene's actual act
     const sceneActNumber = scene.actNumber !== undefined ? scene.actNumber : 1;
-    const actIndex = sortByWhen
+    const rawActIndex = sortByWhen
       ? 0
       : (isSagaScope ? (typeof scene.bookIndex === 'number' ? scene.bookIndex : 0) : (sceneActNumber - 1));
+    // Clamp to the nearest valid quadrant — see renderNumberSquaresUnified above.
+    const actIndex = Math.min(Math.max(rawActIndex, 0), totalActs - 1);
 
     const scenesInActAndSubplot = (scenesByActAndSubplot[actIndex] && scenesByActAndSubplot[actIndex][subplot]) || [];
     const filteredScenesForIndex = scenesInActAndSubplot.filter(s => !isBeatNote(s));

--- a/src/renderer/utils/Precompute.test.ts
+++ b/src/renderer/utils/Precompute.test.ts
@@ -51,4 +51,48 @@ describe('computeCacheableValues', () => {
 
         expect(values.maxStageColor).toBe('#3366ff');
     });
+
+    it('clamps an out-of-range actNumber to the last quadrant instead of wrapping to Act 1', () => {
+        // Regression test for GH #31: a scene whose actNumber exceeds the
+        // currently configured actCount (e.g. cached from before the user
+        // lowered actCount) must land in the last valid quadrant, not
+        // silently collapse into Act 1's quadrant.
+        const plugin = {
+            settings: {
+                currentMode: 'narrative',
+                publishStageColors: {
+                    Zero: '#9900ff',
+                    Author: '#3366ff',
+                    House: '#33aa44',
+                    Press: '#ffaa00',
+                },
+                subplotColors: ['#eeeeee'],
+                enableAiSceneAnalysis: false,
+                actCount: 3,
+            },
+            searchActive: false,
+            searchResults: new Set<string>(),
+            searchTerm: '',
+            openScenePaths: new Set<string>(),
+            desaturateColor: (hex: string) => hex,
+            calculateCompletionEstimate: () => null,
+            synopsisManager: {
+                generateElement: () => document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+            },
+        };
+        const scenes: TimelineItem[] = [
+            {
+                title: '1 Stale Act Four Scene',
+                path: 'Book/1 Stale.md',
+                date: '',
+                subplot: 'Main Plot',
+                actNumber: 4,
+            },
+        ];
+
+        const values = computeCacheableValues(plugin as never, scenes);
+
+        expect(values.scenesByActAndSubplot[2]['Main Plot']).toHaveLength(1);
+        expect(values.scenesByActAndSubplot[0]['Main Plot'] ?? []).toHaveLength(0);
+    });
 });

--- a/src/renderer/utils/Precompute.ts
+++ b/src/renderer/utils/Precompute.ts
@@ -150,7 +150,11 @@ export function computeCacheableValues(
             const act = isSagaScope
                 ? (typeof scene.bookIndex === 'number' ? scene.bookIndex : 0)
                 : (scene.actNumber !== undefined ? scene.actNumber - 1 : 0);
-            const validAct = (act >= 0 && act < numActs) ? act : 0;
+            // Clamp to the nearest valid quadrant instead of resetting to 0 — an
+            // out-of-range act (e.g. stale actNumber cached from a since-lowered
+            // actCount) must not collapse into Act 1's quadrant. Mirrors the
+            // clamping already used for the same case in AprRenderer.ts.
+            const validAct = Math.min(Math.max(act, 0), numActs - 1);
             const subplot = scene.subplot && scene.subplot.trim().length > 0 ? scene.subplot : 'Main Plot';
             if (!scenesByActAndSubplot[validAct][subplot]) {
                 scenesByActAndSubplot[validAct][subplot] = [];

--- a/src/settings/sections/PublishSection.ts
+++ b/src/settings/sections/PublishSection.ts
@@ -46,6 +46,7 @@ import {
     acknowledgeHotfixHistory,
     ensureBundledLayoutInstalledForExport,
     ensureBundledPandocLayoutsRegistered,
+    formatBundledFontInstallSummary,
     getBundledPandocLayouts,
     installBundledPandocLayouts,
     isBundledPandocLayoutInstalled
@@ -405,8 +406,8 @@ async function ensurePublishingEnvironment(plugin: RadialTimelinePlugin): Promis
         if (result.failed.length > 0) {
             issues.push(`Failed to install templates: ${result.failed.join(', ')}`);
         }
-        if (result.fontsFailed.length > 0) {
-            issues.push(`Failed to install bundled fonts: ${result.fontsFailed.join(', ')}. PDF export will fall back to system fonts where available.`);
+        if (result.fonts.failed.length > 0) {
+            issues.push(`Failed to install bundled fonts: ${result.fonts.failed.join(', ')}. PDF export will fall back to system fonts where available.`);
         }
         for (const layout of getBundledPandocLayouts()) {
             const refresh = await ensureBundledLayoutInstalledForExport(plugin, layout);
@@ -1580,8 +1581,11 @@ async function generateSampleTemplates(
     }
 
     const bundledInstall = await installBundledPandocLayouts(plugin);
-    if (bundledInstall.fontsFailed.length > 0) {
-        console.warn(`[Radial Timeline] Bundled font install failed for: ${bundledInstall.fontsFailed.join(', ')}. PDF export will fall back to system fonts where available.`);
+    if (bundledInstall.fonts.failed.length > 0) {
+        console.warn(`[Radial Timeline] Bundled font install failed for: ${bundledInstall.fonts.failed.join(', ')}. PDF export will fall back to system fonts where available.`);
+    } else {
+        const fontSummary = formatBundledFontInstallSummary(bundledInstall.fonts);
+        if (fontSummary) console.info(`[Radial Timeline] Bundled fonts verified on disk —\n${fontSummary}`);
     }
     const installedBundledFilenames = getBundledPandocLayouts()
         .filter(layout => bundledInstall.installed.includes(layout.name))
@@ -2617,15 +2621,16 @@ export function renderPublishSection({ app, plugin, containerEl }: PublishSectio
                             if (ensureBundledPandocLayoutsRegistered(plugin)) {
                                 await plugin.saveSettings();
                             }
-                            const fontsFailed = result.fontsFailed.length > 0 || refresh.fontsFailed;
+                            const failedFontFamilies = [...new Set([...result.fonts.failed, ...refresh.fonts.failed])];
+                            const fontSummary = formatBundledFontInstallSummary(result.fonts);
                             if (result.failed.length > 0 || refresh.failed) {
                                 new Notice(`Failed to install bundled layout: ${getLayoutDisplayName(layout)}`);
-                            } else if (fontsFailed) {
-                                new Notice(`Installed layout template for ${getLayoutDisplayName(layout)}, but required fonts failed to copy. PDF export will fall back to system fonts where available.`);
+                            } else if (failedFontFamilies.length > 0) {
+                                new Notice(`Installed layout template for ${getLayoutDisplayName(layout)}, but required fonts failed to copy (${failedFontFamilies.join(', ')}). PDF export will fall back to system fonts where available.`);
                             } else if (result.installed.length > 0) {
-                                new Notice(`Installed bundled layout and required fonts: ${getLayoutDisplayName(layout)}`);
+                                new Notice(`Installed bundled layout and required fonts: ${getLayoutDisplayName(layout)}${fontSummary ? `\n\n${fontSummary}` : ''}`, 12000);
                             } else {
-                                new Notice(`Bundled layout and required fonts are already installed: ${getLayoutDisplayName(layout)}`);
+                                new Notice(`Bundled layout and required fonts are already installed: ${getLayoutDisplayName(layout)}${fontSummary ? `\n\n${fontSummary}` : ''}`, 12000);
                             }
                             renderLayoutRows();
                             refreshPublishingStatusCard();
@@ -2997,9 +3002,12 @@ export function renderPublishSection({ app, plugin, containerEl }: PublishSectio
                     await plugin.saveSettings();
                 }
                 const refreshFailures = refreshResults.filter(item => item.failed).length;
-                const fontsFailed = result.fontsFailed.length > 0 || refreshResults.some(item => item.fontsFailed);
-                if (refreshFailures > 0 || result.failed.length > 0 || fontsFailed) {
-                    new Notice('Some bundled layouts or required fonts failed to install.');
+                const failedFontFamilies = [...new Set([
+                    ...result.fonts.failed,
+                    ...refreshResults.flatMap(item => item.fonts.failed)
+                ])];
+                if (refreshFailures > 0 || result.failed.length > 0 || failedFontFamilies.length > 0) {
+                    new Notice(`Some bundled layouts or required fonts failed to install${failedFontFamilies.length > 0 ? ` (fonts: ${failedFontFamilies.join(', ')})` : ''}.`);
                 } else {
                     // Templates and fonts are now current on disk, so clear the
                     // "Update templates" nudge by acknowledging the hotfix
@@ -3009,10 +3017,11 @@ export function renderPublishSection({ app, plugin, containerEl }: PublishSectio
                         plugin.settings.templateHotfixHistory
                     );
                     await plugin.saveSettings();
+                    const fontSummary = formatBundledFontInstallSummary(result.fonts);
                     if (result.installed.length > 0) {
-                        new Notice(`Installed ${result.installed.length} bundled layout template(s) and required fonts in ${getConfiguredPandocFolder(plugin)}/.`);
+                        new Notice(`Installed ${result.installed.length} bundled layout template(s) and required fonts in ${getConfiguredPandocFolder(plugin)}/.${fontSummary ? `\n\n${fontSummary}` : ''}`, 12000);
                     } else {
-                        new Notice('Bundled layouts and required fonts are installed and refreshed.');
+                        new Notice(`Bundled layouts and required fonts are installed and refreshed.${fontSummary ? `\n\n${fontSummary}` : ''}`, 12000);
                     }
                 }
                 renderLayoutRows();

--- a/src/settings/sections/PublishSection.ts
+++ b/src/settings/sections/PublishSection.ts
@@ -47,9 +47,11 @@ import {
     ensureBundledLayoutInstalledForExport,
     ensureBundledPandocLayoutsRegistered,
     formatBundledFontInstallSummary,
+    formatFontFileSize,
     getBundledPandocLayouts,
     installBundledPandocLayouts,
-    isBundledPandocLayoutInstalled
+    isBundledPandocLayoutInstalled,
+    type BundledFontInstallResult
 } from '../../utils/pandocBundledLayouts';
 import { getPandocLayoutTier } from '../../publishing/templateTiering';
 import {
@@ -92,6 +94,55 @@ function fileExistsSync(absPath: string): boolean {
     } catch {
         return false;
     }
+}
+
+/**
+ * Reveal a file in the OS file manager (Finder on macOS, Explorer on
+ * Windows, default file manager on Linux), highlighting it in its
+ * containing folder. Desktop-only (electron.shell); shows a Notice instead
+ * of failing silently if unavailable.
+ */
+function revealAbsolutePathInFileManager(absolutePath: string): void {
+    try {
+        // electron.shell is available in the desktop renderer process
+        const electron = (window as unknown as { require?: (name: string) => { shell?: { showItemInFolder: (p: string) => void } } }).require?.('electron'); // SAFE: Electron shell reveal is the standard desktop-only way to open Finder/Explorer at a file.
+        const shell = electron?.shell;
+        if (!shell) {
+            new Notice(`Could not open file manager. Path: ${absolutePath}`);
+            return;
+        }
+        shell.showItemInFolder(absolutePath);
+    } catch {
+        new Notice(`Could not open file manager. Path: ${absolutePath}`);
+    }
+}
+
+/**
+ * Build a rich Notice fragment: a headline plus one clickable pill per
+ * installed/verified font file (abbreviated name, folder, size). Clicking a
+ * pill reveals that exact file in the OS file manager so the user can
+ * verify it themselves rather than take the Notice's word for it. Returns
+ * null when there is nothing to show (e.g. install failed before any font
+ * was touched).
+ */
+function buildFontPillsNotice(ownerDoc: Document, headline: string, fonts: BundledFontInstallResult): DocumentFragment | string {
+    const families = [...fonts.installed, ...fonts.alreadyPresent].filter(f => f.files.length > 0);
+    if (families.length === 0) return headline;
+
+    const fragment = ownerDoc.createDocumentFragment();
+    const wrapper = fragment.createDiv();
+    wrapper.createDiv({ text: headline });
+    const row = wrapper.createDiv({ cls: 'ert-font-pill-row' });
+    for (const { family, files } of families) {
+        for (const file of files) {
+            const pill = row.createEl('button', { cls: 'ert-font-pill', attr: { type: 'button' } });
+            pill.createSpan({ cls: 'ert-font-pill-name', text: file.file });
+            pill.createSpan({ cls: 'ert-font-pill-meta', text: `fonts/${family} · ${formatFontFileSize(file.sizeBytes)}` });
+            pill.setAttribute('title', `${file.absolutePath}\nClick to reveal in file manager.`);
+            pill.addEventListener('click', () => revealAbsolutePathInFileManager(file.absolutePath));
+        }
+    }
+    return fragment;
 }
 
 /**
@@ -2622,15 +2673,14 @@ export function renderPublishSection({ app, plugin, containerEl }: PublishSectio
                                 await plugin.saveSettings();
                             }
                             const failedFontFamilies = [...new Set([...result.fonts.failed, ...refresh.fonts.failed])];
-                            const fontSummary = formatBundledFontInstallSummary(result.fonts);
                             if (result.failed.length > 0 || refresh.failed) {
                                 new Notice(`Failed to install bundled layout: ${getLayoutDisplayName(layout)}`);
                             } else if (failedFontFamilies.length > 0) {
                                 new Notice(`Installed layout template for ${getLayoutDisplayName(layout)}, but required fonts failed to copy (${failedFontFamilies.join(', ')}). PDF export will fall back to system fonts where available.`);
                             } else if (result.installed.length > 0) {
-                                new Notice(`Installed bundled layout and required fonts: ${getLayoutDisplayName(layout)}${fontSummary ? `\n\n${fontSummary}` : ''}`, 12000);
+                                new Notice(buildFontPillsNotice(btn.buttonEl.ownerDocument, `Installed bundled layout and required fonts: ${getLayoutDisplayName(layout)}`, result.fonts), 12000);
                             } else {
-                                new Notice(`Bundled layout and required fonts are already installed: ${getLayoutDisplayName(layout)}${fontSummary ? `\n\n${fontSummary}` : ''}`, 12000);
+                                new Notice(buildFontPillsNotice(btn.buttonEl.ownerDocument, `Bundled layout and required fonts are already installed: ${getLayoutDisplayName(layout)}`, result.fonts), 12000);
                             }
                             renderLayoutRows();
                             refreshPublishingStatusCard();
@@ -3017,11 +3067,10 @@ export function renderPublishSection({ app, plugin, containerEl }: PublishSectio
                         plugin.settings.templateHotfixHistory
                     );
                     await plugin.saveSettings();
-                    const fontSummary = formatBundledFontInstallSummary(result.fonts);
                     if (result.installed.length > 0) {
-                        new Notice(`Installed ${result.installed.length} bundled layout template(s) and required fonts in ${getConfiguredPandocFolder(plugin)}/.${fontSummary ? `\n\n${fontSummary}` : ''}`, 12000);
+                        new Notice(buildFontPillsNotice(button.buttonEl.ownerDocument, `Installed ${result.installed.length} bundled layout template(s) and required fonts in ${getConfiguredPandocFolder(plugin)}/.`, result.fonts), 12000);
                     } else {
-                        new Notice(`Bundled layouts and required fonts are installed and refreshed.${fontSummary ? `\n\n${fontSummary}` : ''}`, 12000);
+                        new Notice(buildFontPillsNotice(button.buttonEl.ownerDocument, 'Bundled layouts and required fonts are installed and refreshed.', result.fonts), 12000);
                     }
                 }
                 renderLayoutRows();

--- a/src/settings/sections/PublishSection.ts
+++ b/src/settings/sections/PublishSection.ts
@@ -405,6 +405,9 @@ async function ensurePublishingEnvironment(plugin: RadialTimelinePlugin): Promis
         if (result.failed.length > 0) {
             issues.push(`Failed to install templates: ${result.failed.join(', ')}`);
         }
+        if (result.fontsFailed.length > 0) {
+            issues.push(`Failed to install bundled fonts: ${result.fontsFailed.join(', ')}. PDF export will fall back to system fonts where available.`);
+        }
         for (const layout of getBundledPandocLayouts()) {
             const refresh = await ensureBundledLayoutInstalledForExport(plugin, layout);
             if (refresh.failed) {
@@ -1577,6 +1580,9 @@ async function generateSampleTemplates(
     }
 
     const bundledInstall = await installBundledPandocLayouts(plugin);
+    if (bundledInstall.fontsFailed.length > 0) {
+        console.warn(`[Radial Timeline] Bundled font install failed for: ${bundledInstall.fontsFailed.join(', ')}. PDF export will fall back to system fonts where available.`);
+    }
     const installedBundledFilenames = getBundledPandocLayouts()
         .filter(layout => bundledInstall.installed.includes(layout.name))
         .map(layout => layout.path);
@@ -2611,8 +2617,11 @@ export function renderPublishSection({ app, plugin, containerEl }: PublishSectio
                             if (ensureBundledPandocLayoutsRegistered(plugin)) {
                                 await plugin.saveSettings();
                             }
+                            const fontsFailed = result.fontsFailed.length > 0 || refresh.fontsFailed;
                             if (result.failed.length > 0 || refresh.failed) {
                                 new Notice(`Failed to install bundled layout: ${getLayoutDisplayName(layout)}`);
+                            } else if (fontsFailed) {
+                                new Notice(`Installed layout template for ${getLayoutDisplayName(layout)}, but required fonts failed to copy. PDF export will fall back to system fonts where available.`);
                             } else if (result.installed.length > 0) {
                                 new Notice(`Installed bundled layout and required fonts: ${getLayoutDisplayName(layout)}`);
                             } else {
@@ -2988,7 +2997,8 @@ export function renderPublishSection({ app, plugin, containerEl }: PublishSectio
                     await plugin.saveSettings();
                 }
                 const refreshFailures = refreshResults.filter(item => item.failed).length;
-                if (refreshFailures > 0 || result.failed.length > 0) {
+                const fontsFailed = result.fontsFailed.length > 0 || refreshResults.some(item => item.fontsFailed);
+                if (refreshFailures > 0 || result.failed.length > 0 || fontsFailed) {
                     new Notice('Some bundled layouts or required fonts failed to install.');
                 } else {
                     // Templates and fonts are now current on disk, so clear the

--- a/src/styles/pulse.css
+++ b/src/styles/pulse.css
@@ -3308,6 +3308,47 @@ body > .tooltip {
   background: var(--background-modifier-hover);
 }
 
+/* Clickable font pills in the "Install" Notice — one per verified font file,
+   abbreviated name/folder/size, click to reveal in Finder/Explorer. */
+.ert-font-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ert-gap-tight, 6px);
+  margin-top: var(--ert-gap-tight, 6px);
+}
+
+.ert-font-pill {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--ert-gap-2xs, 4px);
+  max-width: 100%;
+  padding: 2px 10px;
+  background: var(--background-modifier-form-field, var(--background-secondary));
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  color: var(--text-normal);
+  cursor: pointer;
+}
+
+.ert-font-pill:hover {
+  background: var(--background-modifier-hover);
+  border-color: var(--interactive-accent);
+}
+
+.ert-font-pill-name {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 180px;
+}
+
+.ert-font-pill-meta {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
 .ert-style-wizard__toggle {
   display: inline-flex;
   align-items: center;

--- a/src/utils/pandocBundledLayouts.test.ts
+++ b/src/utils/pandocBundledLayouts.test.ts
@@ -12,9 +12,11 @@ import {
     ensureBundledLayoutInstalledForExport,
     ensureBundledPandocLayoutsRegistered,
     ensureSpecDrivenBundledFictionTemplatesCurrent,
+    formatBundledFontInstallSummary,
     getVaultFontDir,
     getBundledPandocLayoutContent,
     getBundledPandocLayouts,
+    installBundledPandocFonts,
     installBundledPandocLayouts,
     setBundledFontSourcePath,
     setPandocFontPathsForVault,
@@ -456,6 +458,66 @@ describe('bundled pandoc layout export auto-install', () => {
         expect(history).toHaveLength(1);
         expect(history[0].layoutId).toBe(layout.id);
         expect(history[0].hotfixId).toBe(HOTFIX_ID_SPEC_DRIFT_OVERWRITE);
+    });
+
+    /**
+     * Regression for GH #29 (part 2): the "Install" Notice must never claim
+     * fonts were installed when the on-disk result doesn't actually match the
+     * source byte-for-byte. Simulates a silently truncated write (the real
+     * failure mode a full disk or interrupted copy would produce) and
+     * verifies every affected family is reported as failed, not installed.
+     */
+    it('never reports a font family as installed/already-present when the bundled source asset itself is empty', async () => {
+        const { plugin } = createPluginWithBundledLayout('bundled-fiction-contemporary-literary');
+        const vaultBase = (plugin.app.vault.adapter as unknown as { getBasePath: () => string }).getBasePath(); // SAFE: test asserts against the desktop vault base path used for local font installation.
+        const sourceFontsRoot = path.join(vaultBase, '.obsidian/plugins/radial-timeline/assets/fonts');
+        // Simulate the real-world failure mode this guards against: a bundled
+        // asset that is corrupt/empty on disk (e.g. a build step that failed
+        // silently), not a copy error we'd have to fake.
+        fs.writeFileSync(path.join(sourceFontsRoot, 'source-serif-4', 'SourceSerif4-Regular.otf'), '');
+
+        const result = await installBundledPandocFonts(plugin);
+
+        expect(result.installed.find(f => f.family === 'source-serif-4')).toBeUndefined();
+        expect(result.alreadyPresent.find(f => f.family === 'source-serif-4')).toBeUndefined();
+        expect(result.failed).toContain('source-serif-4');
+        // Unaffected families must still succeed — one corrupt family
+        // shouldn't cascade into failing everything.
+        expect(result.failed).not.toContain('latin-modern');
+        expect(result.failed).not.toContain('sorts-mill-goudy');
+    });
+
+    /**
+     * Regression for GH #29 (part 3): the success Notice must be able to show
+     * the user exactly which files landed, their real on-disk size, and
+     * where — not just the word "installed". LICENSE/README text files that
+     * are copied alongside source-serif-4 must not be reported as if they
+     * were fonts.
+     */
+    it('reports installed font files with their verified on-disk size and absolute folder location', async () => {
+        const { plugin } = createPluginWithBundledLayout('bundled-fiction-contemporary-literary');
+
+        const result = await installBundledPandocFonts(plugin);
+
+        expect(result.failed).toEqual([]);
+        expect(result.targetRoot).toBeTruthy();
+        expect(result.targetRoot).toContain('fonts');
+
+        const sourceSerif = result.installed.find(f => f.family === 'source-serif-4');
+        expect(sourceSerif).toBeTruthy();
+        const regular = sourceSerif!.files.find(f => f.file === 'SourceSerif4-Regular.otf');
+        expect(regular).toBeTruthy();
+        expect(regular!.sizeBytes).toBeGreaterThan(0);
+        // LICENSE.md/README.md are copied alongside this family but must
+        // never be listed as if they were font files.
+        expect(sourceSerif!.files.some(f => f.file === 'LICENSE.md' || f.file === 'README.md')).toBe(false);
+
+        const summary = formatBundledFontInstallSummary(result);
+        expect(summary).toContain('source-serif-4/');
+        expect(summary).toContain('SourceSerif4-Regular.otf');
+        expect(summary).toContain('Location:');
+        expect(summary).toContain(result.targetRoot!);
+        expect(summary).not.toContain('LICENSE.md');
     });
 
     it('seeds the registry so install-all leaves all bundled fiction layouts validating', async () => {

--- a/src/utils/pandocBundledLayouts.test.ts
+++ b/src/utils/pandocBundledLayouts.test.ts
@@ -508,6 +508,13 @@ describe('bundled pandoc layout export auto-install', () => {
         const regular = sourceSerif!.files.find(f => f.file === 'SourceSerif4-Regular.otf');
         expect(regular).toBeTruthy();
         expect(regular!.sizeBytes).toBeGreaterThan(0);
+        // absolutePath must point at the exact file whose size we just
+        // verified — this is what the Settings pill's "reveal in Finder"
+        // click action opens, so it must resolve to a real file, not just
+        // the family folder.
+        expect(regular!.absolutePath).toBe(path.join(result.targetRoot!, 'source-serif-4', 'SourceSerif4-Regular.otf'));
+        expect(fs.existsSync(regular!.absolutePath)).toBe(true);
+        expect(fs.statSync(regular!.absolutePath).size).toBe(regular!.sizeBytes);
         // LICENSE.md/README.md are copied alongside this family but must
         // never be listed as if they were font files.
         expect(sourceSerif!.files.some(f => f.file === 'LICENSE.md' || f.file === 'README.md')).toBe(false);

--- a/src/utils/pandocBundledLayouts.ts
+++ b/src/utils/pandocBundledLayouts.ts
@@ -411,18 +411,44 @@ export function setPandocFontPathsForVault(plugin: RadialTimelinePlugin): void {
     setVaultFontDir(getPandocFontAbsoluteRoot(plugin));
 }
 
+/** Actual font binaries only — excludes bundled LICENSE/README text files from user-facing reporting. */
+const FONT_BINARY_EXTENSIONS = new Set(['.otf', '.ttf']);
+function isFontBinaryFile(fileName: string): boolean {
+    const ext = fileName.slice(fileName.lastIndexOf('.')).toLowerCase();
+    return FONT_BINARY_EXTENSIONS.has(ext);
+}
+
+export interface BundledFontFileStatus {
+    file: string;
+    sizeBytes: number;
+}
+
+export interface BundledFontFamilyStatus {
+    family: string;
+    /** Font binaries only (LICENSE/README are copied but not reported here). */
+    files: BundledFontFileStatus[];
+}
+
+export interface BundledFontInstallResult {
+    installed: BundledFontFamilyStatus[];
+    alreadyPresent: BundledFontFamilyStatus[];
+    failed: string[];
+    /** Absolute filesystem folder these fonts were installed under, e.g. ".../Radial Timeline/Pandoc/fonts". */
+    targetRoot?: string;
+}
+
 export async function installBundledPandocFonts(
     plugin: RadialTimelinePlugin
-): Promise<{ installed: string[]; alreadyPresent: string[]; failed: string[] }> {
+): Promise<BundledFontInstallResult> {
     const sourceRoot = MODULE_BUNDLED_FONT_SOURCE_PATH;
     const targetRoot = getPandocFontAbsoluteRoot(plugin);
-    const installed: string[] = [];
-    const alreadyPresent: string[] = [];
+    const installed: BundledFontFamilyStatus[] = [];
+    const alreadyPresent: BundledFontFamilyStatus[] = [];
     const failed: string[] = [];
 
     if (!sourceRoot || !targetRoot) {
         for (const family of Object.keys(BUNDLED_PANDOC_FONT_FILES)) failed.push(family);
-        return { installed, alreadyPresent, failed };
+        return { installed, alreadyPresent, failed, targetRoot };
     }
 
     for (const [family, files] of Object.entries(BUNDLED_PANDOC_FONT_FILES)) {
@@ -431,27 +457,40 @@ export async function installBundledPandocFonts(
         try {
             fs.mkdirSync(targetDir, { recursive: true });
             let changed = false;
+            const verifiedFiles: BundledFontFileStatus[] = [];
             for (const file of files) {
                 const sourceFile = path.join(sourceDir, file);
                 const targetFile = path.join(targetDir, file);
                 if (!fs.existsSync(sourceFile)) {
                     throw new Error(`Missing bundled font asset: ${sourceFile}`);
                 }
+                const sourceSize = fs.statSync(sourceFile).size;
                 const needsCopy = !fs.existsSync(targetFile)
-                    || fs.statSync(sourceFile).size !== fs.statSync(targetFile).size;
+                    || fs.statSync(targetFile).size !== sourceSize;
                 if (needsCopy) {
                     fs.copyFileSync(sourceFile, targetFile);
                     changed = true;
                 }
+                // Verify the file on disk after copying (or after finding it
+                // already present) actually matches the source byte-for-byte
+                // in size. A short write or zero-byte file must never be
+                // reported as a successful install (GH #29).
+                const finalSize = fs.existsSync(targetFile) ? fs.statSync(targetFile).size : 0;
+                if (finalSize === 0 || finalSize !== sourceSize) {
+                    throw new Error(`Font file verification failed after copy: ${targetFile} (expected ${sourceSize} bytes, found ${finalSize})`);
+                }
+                if (isFontBinaryFile(file)) {
+                    verifiedFiles.push({ file, sizeBytes: finalSize });
+                }
             }
-            if (changed) installed.push(family);
-            else alreadyPresent.push(family);
+            if (changed) installed.push({ family, files: verifiedFiles });
+            else alreadyPresent.push({ family, files: verifiedFiles });
         } catch {
             failed.push(family);
         }
     }
 
-    return { installed, alreadyPresent, failed };
+    return { installed, alreadyPresent, failed, targetRoot };
 }
 
 /**
@@ -528,7 +567,7 @@ export function isBundledPandocLayoutInstalled(plugin: RadialTimelinePlugin, lay
 export async function installBundledPandocLayouts(
     plugin: RadialTimelinePlugin,
     layoutIds?: string[]
-): Promise<{ installed: string[]; alreadyPresent: string[]; failed: string[]; fontsFailed: string[] }> {
+): Promise<{ installed: string[]; alreadyPresent: string[]; failed: string[]; fonts: BundledFontInstallResult }> {
     const vault = plugin.app.vault;
     const selected = BUNDLED_PANDOC_LAYOUT_TEMPLATES.filter(layout => !layoutIds || layoutIds.includes(layout.id));
     const pandocFolder = getPandocFolder(plugin);
@@ -583,7 +622,7 @@ export async function installBundledPandocLayouts(
         }
     }
 
-    return { installed, alreadyPresent, failed, fontsFailed: fontsResult.failed };
+    return { installed, alreadyPresent, failed, fonts: fontsResult };
 }
 
 export async function ensureSpecDrivenBundledFictionTemplatesCurrent(
@@ -694,14 +733,17 @@ export function acknowledgeHotfixHistory(
 export async function ensureBundledLayoutInstalledForExport(
     plugin: RadialTimelinePlugin,
     layout: PandocLayoutTemplate
-): Promise<{ installed: boolean; failed: boolean; fontsFailed: boolean }> {
-    if (!layout.bundled) return { installed: false, failed: false, fontsFailed: false };
+): Promise<{ installed: boolean; failed: boolean; fonts: BundledFontInstallResult }> {
+    const emptyFonts: BundledFontInstallResult = { installed: [], alreadyPresent: [], failed: [] };
+    if (!layout.bundled) return { installed: false, failed: false, fonts: emptyFonts };
 
     // Export can be reached long after a bundled .tex template was installed.
     // Refresh the vault-local font assets every time so newly bundled fonts
-    // self-heal without asking users to delete or move files by hand.
-    const fontsResult = await installBundledPandocFonts(plugin);
-    const fontsFailed = fontsResult.failed.length > 0;
+    // self-heal without asking users to delete or move files by hand. This
+    // call is authoritative for font install/verification status — the
+    // installBundledPandocLayouts call below also touches fonts, but only
+    // redundantly (idempotent copy), so its result isn't re-merged here.
+    const fonts = await installBundledPandocFonts(plugin);
     setPandocFontPathsForVault(plugin);
 
     // For spec-driven bundled fiction layouts, the .tex on disk is a derived
@@ -740,12 +782,34 @@ export async function ensureBundledLayoutInstalledForExport(
         }
     }
 
-    if (isBundledPandocLayoutInstalled(plugin, layout)) return { installed: false, failed: false, fontsFailed };
+    if (isBundledPandocLayoutInstalled(plugin, layout)) return { installed: false, failed: false, fonts };
 
     const result = await installBundledPandocLayouts(plugin, [layout.id]);
     return {
         installed: result.installed.length > 0,
         failed: result.failed.length > 0,
-        fontsFailed: fontsFailed || result.fontsFailed.length > 0
+        fonts
     };
+}
+
+function formatFontFileSize(bytes: number): string {
+    if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+    return `${bytes} B`;
+}
+
+/**
+ * Human-readable breakdown of exactly which font files are on disk and
+ * where — not just "fonts installed". Each size comes from a post-copy
+ * `fs.statSync` read (see `installBundledPandocFonts`), so a zero-byte or
+ * truncated file is never reported here as present (GH #29).
+ */
+export function formatBundledFontInstallSummary(fonts: BundledFontInstallResult): string {
+    const families = [...fonts.installed, ...fonts.alreadyPresent].filter(f => f.files.length > 0);
+    if (families.length === 0) return '';
+    const lines = families.map(({ family, files }) => {
+        const fileList = files.map(f => `${f.file} (${formatFontFileSize(f.sizeBytes)})`).join(', ');
+        return `${family}/: ${fileList}`;
+    });
+    const location = fonts.targetRoot ? `Location: ${fonts.targetRoot}` : '';
+    return [...lines, location].filter(Boolean).join('\n');
 }

--- a/src/utils/pandocBundledLayouts.ts
+++ b/src/utils/pandocBundledLayouts.ts
@@ -421,6 +421,8 @@ function isFontBinaryFile(fileName: string): boolean {
 export interface BundledFontFileStatus {
     file: string;
     sizeBytes: number;
+    /** Absolute filesystem path to this exact file, for "reveal in Finder/Explorer" actions. */
+    absolutePath: string;
 }
 
 export interface BundledFontFamilyStatus {
@@ -480,7 +482,7 @@ export async function installBundledPandocFonts(
                     throw new Error(`Font file verification failed after copy: ${targetFile} (expected ${sourceSize} bytes, found ${finalSize})`);
                 }
                 if (isFontBinaryFile(file)) {
-                    verifiedFiles.push({ file, sizeBytes: finalSize });
+                    verifiedFiles.push({ file, sizeBytes: finalSize, absolutePath: targetFile });
                 }
             }
             if (changed) installed.push({ family, files: verifiedFiles });
@@ -792,7 +794,7 @@ export async function ensureBundledLayoutInstalledForExport(
     };
 }
 
-function formatFontFileSize(bytes: number): string {
+export function formatFontFileSize(bytes: number): string {
     if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)} KB`;
     return `${bytes} B`;
 }

--- a/src/utils/pandocBundledLayouts.ts
+++ b/src/utils/pandocBundledLayouts.ts
@@ -528,7 +528,7 @@ export function isBundledPandocLayoutInstalled(plugin: RadialTimelinePlugin, lay
 export async function installBundledPandocLayouts(
     plugin: RadialTimelinePlugin,
     layoutIds?: string[]
-): Promise<{ installed: string[]; alreadyPresent: string[]; failed: string[] }> {
+): Promise<{ installed: string[]; alreadyPresent: string[]; failed: string[]; fontsFailed: string[] }> {
     const vault = plugin.app.vault;
     const selected = BUNDLED_PANDOC_LAYOUT_TEMPLATES.filter(layout => !layoutIds || layoutIds.includes(layout.id));
     const pandocFolder = getPandocFolder(plugin);
@@ -536,7 +536,7 @@ export async function installBundledPandocLayouts(
     if (!vault.getAbstractFileByPath(pandocFolder)) {
         await ensureFolderPath(plugin, pandocFolder);
     }
-    await installBundledPandocFonts(plugin);
+    const fontsResult = await installBundledPandocFonts(plugin);
     setPandocFontPathsForVault(plugin);
 
     const installed: string[] = [];
@@ -583,7 +583,7 @@ export async function installBundledPandocLayouts(
         }
     }
 
-    return { installed, alreadyPresent, failed };
+    return { installed, alreadyPresent, failed, fontsFailed: fontsResult.failed };
 }
 
 export async function ensureSpecDrivenBundledFictionTemplatesCurrent(
@@ -694,13 +694,14 @@ export function acknowledgeHotfixHistory(
 export async function ensureBundledLayoutInstalledForExport(
     plugin: RadialTimelinePlugin,
     layout: PandocLayoutTemplate
-): Promise<{ installed: boolean; failed: boolean }> {
-    if (!layout.bundled) return { installed: false, failed: false };
+): Promise<{ installed: boolean; failed: boolean; fontsFailed: boolean }> {
+    if (!layout.bundled) return { installed: false, failed: false, fontsFailed: false };
 
     // Export can be reached long after a bundled .tex template was installed.
     // Refresh the vault-local font assets every time so newly bundled fonts
     // self-heal without asking users to delete or move files by hand.
-    await installBundledPandocFonts(plugin);
+    const fontsResult = await installBundledPandocFonts(plugin);
+    const fontsFailed = fontsResult.failed.length > 0;
     setPandocFontPathsForVault(plugin);
 
     // For spec-driven bundled fiction layouts, the .tex on disk is a derived
@@ -739,11 +740,12 @@ export async function ensureBundledLayoutInstalledForExport(
         }
     }
 
-    if (isBundledPandocLayoutInstalled(plugin, layout)) return { installed: false, failed: false };
+    if (isBundledPandocLayoutInstalled(plugin, layout)) return { installed: false, failed: false, fontsFailed };
 
     const result = await installBundledPandocLayouts(plugin, [layout.id]);
     return {
         installed: result.installed.length > 0,
-        failed: result.failed.length > 0
+        failed: result.failed.length > 0,
+        fontsFailed: fontsFailed || result.fontsFailed.length > 0
     };
 }


### PR DESCRIPTION
## Summary

Fixes for two open bugs found during a scheduled cross-channel review, plus two follow-up hardening passes on the font-install reporting. All root-caused, fixed, and verified.

### #31 — Narrative Mode scenes render in the wrong Act quadrant (wraparound)

`src/renderer/utils/Precompute.ts` bucketed scenes into quadrants with:
```js
const validAct = (act >= 0 && act < numActs) ? act : 0;
```
Any out-of-range act (e.g. a scene's cached `actNumber` from before the user lowered `actCount`) silently fell back to **quadrant 0 (Act 1)** instead of the nearest valid quadrant — matching the exact symptom in the issue (scenes clustering into Act 1/Act 4, actCount 4→3 collapsing most scenes into Act 1). `AprRenderer.ts` already handles the identical case correctly with `Math.min(actIdx, numActs - 1)`.

Fixed by clamping instead of resetting to 0, in `Precompute.ts` and in the two renderer files that independently re-derive the same act index for label/number placement (`NumberSquares.ts` ×2, `TimelineRenderer.ts`) — without the same clamp there, a scene rebucketed correctly by `Precompute.ts` would still look up an empty scene list and re-derive a wrapped-around angle for its number square / scene id.

Added a regression test in `Precompute.test.ts`; confirmed it fails against the prior logic and passes with the fix (verified via `git stash` on just the source fix, not the test).

### #29 — "Install bundled fonts" reports success even when nothing installed

`installBundledPandocLayouts()` and `ensureBundledLayoutInstalledForExport()` both called `installBundledPandocFonts()` but discarded its `{ failed }` result. Every install path (single-layout "Install" button, "Install all", auto-configure) built its success/failure notice only from the `.tex` **template** write result — which almost always succeeds since the template content is an inline string — so a font-copy failure was invisible and the UI always said "required fonts" were installed.

Both functions now return the full font install result, and all four Publish-settings call sites check its `failed` field before claiming success.

**Hardening pass 1 (verifiable proof, not just a claim):** `installBundledPandocFonts` now returns each family's actual font file names with their **post-copy on-disk size** (read via `fs.statSync` after the copy) and the **absolute install folder path**, and adds a guard so a family is never reported installed/already-present if the resulting file is empty or doesn't match the source size byte-for-byte. LICENSE/README text files bundled alongside `source-serif-4` are excluded from the reported font list.

**Hardening pass 2 (clickable pills):** the three "Install" Notices now render each verified font as a clickable pill — abbreviated name, `fonts/<family>` folder, size — instead of a plain-text dump. Clicking a pill calls `electron.shell.showItemInFolder` (the same pattern already used in `ManuscriptOptionsModal.ts`/`AuthorProgressModal.ts`) to reveal that exact file in Finder/Explorer, so a user can verify it themselves instead of trusting the text.

Note: this fixes the *dishonest success notice* and adds *verifiable, clickable proof of what's actually on disk*. Whether bundled font files actually reach a production install (vs. only local dev builds) is a separate, deeper packaging question — `.github/workflows/release-build.yml` only uploads `main.js`/`manifest.json`/`styles.css` to releases, so `assets/fonts` may never land in an end-user's plugin folder depending on install path. That needs a product decision (e.g. embedding fonts as base64 in `main.js`, which would add ~2MB to the bundle) and is intentionally **not** included in this PR — flagged separately for a decision.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` (vitest) — 255 files / 2813 tests passed, 0 failed
- [x] `npm run build-only` — clean production build
- [x] `node code-quality-check.mjs --all` — clean
- [x] Regression test for #31 verified to fail against the pre-fix code, pass against the fix
- [x] Regression test for #29's corrupt-file guard verified to fail against the pre-fix code (an empty bundled source asset was silently reported as installed), pass against the fix
- [x] Test confirms reported font file size/location/absolutePath match the real files on disk, and LICENSE/README are excluded from the font list

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
