### PR TITLE
model(promote): Claude Opus 5 replacing Claude Opus 4.7

### DIFF
--- a/docs/engineering/standards/model-promotion.md
+++ b/docs/engineering/standards/model-promotion.md
@@ -11,9 +11,11 @@ This policy was adopted on **2026-05-22** after the audit found that every model
 One top model per provider line, plus a Google fast/deep split where the speed/depth tradeoff is a genuine quality dimension (not a cost dimension), plus an optional **one-back continuity model** on the Anthropic depth lane (see [Continuity models](#continuity-models-one-back)).
 
 ```
-Anthropic: Claude Opus 4.8              (depth, current — auto-selected)
-           Claude Opus 4.7              (depth, one-back continuity)
+Anthropic: Claude Opus 5                (depth, current — auto-selected)
+           Claude Opus 4.8              (depth, one-back continuity)
+           Claude Fable 5               (depth, premium 'pro' channel — explicit choice only)
 OpenAI:    GPT-5.5                       (depth)
+           GPT-5.4                       (economy second on the gpt-5 line)
 Google:    Gemini 3.1 Pro Preview        (depth)
            Gemini 3.5 Flash              (speed — different reasoning style, not just faster)
 Ollama:    llama3, local-model           (local)

--- a/scripts/models/pricing.json
+++ b/scripts/models/pricing.json
@@ -3,7 +3,7 @@
   "models": [
     {
       "provider": "anthropic",
-      "modelId": "claude-opus-4-8",
+      "modelId": "claude-opus-5",
       "inputPer1M": 5,
       "outputPer1M": 25,
       "cacheWrite5mPer1M": 6.25,
@@ -12,7 +12,7 @@
     },
     {
       "provider": "anthropic",
-      "modelId": "claude-opus-4-7",
+      "modelId": "claude-opus-4-8",
       "inputPer1M": 5,
       "outputPer1M": 25,
       "cacheWrite5mPer1M": 6.25,

--- a/scripts/models/registry.json
+++ b/scripts/models/registry.json
@@ -3,6 +3,22 @@
   "models": [
     {
       "provider": "anthropic",
+      "id": "claude-opus-5",
+      "alias": "claude-opus-5",
+      "label": "Claude Opus 5",
+      "line": "claude-opus",
+      "tier": "DEEP",
+      "capabilities": ["longContext", "jsonStrict", "reasoningStrong", "highOutputCap"],
+      "personality": { "reasoning": 10, "writing": 10, "determinism": 9 },
+      "contextWindow": 1000000,
+      "maxOutput": 128000,
+      "releasedAt": "2026-07-24",
+      "status": "stable",
+      "rollout": { "channel": "stable", "status": "stable", "lane": "default" },
+      "constraints": { "supportsTemperature": false, "supportsTopP": false, "supportsAdaptiveThinking": true, "thinkingDefaultsOn": true }
+    },
+    {
+      "provider": "anthropic",
       "id": "claude-opus-4-8",
       "alias": "claude-opus-4.8",
       "label": "Claude Opus 4.8",
@@ -13,22 +29,6 @@
       "contextWindow": 1000000,
       "maxOutput": 128000,
       "releasedAt": "2026-05-28",
-      "status": "stable",
-      "rollout": { "channel": "stable", "status": "stable", "lane": "default" },
-      "constraints": { "supportsTemperature": false, "supportsTopP": false, "supportsAdaptiveThinking": true }
-    },
-    {
-      "provider": "anthropic",
-      "id": "claude-opus-4-7",
-      "alias": "claude-opus-4.7",
-      "label": "Claude Opus 4.7",
-      "line": "claude-opus",
-      "tier": "DEEP",
-      "capabilities": ["longContext", "jsonStrict", "reasoningStrong", "highOutputCap"],
-      "personality": { "reasoning": 10, "writing": 10, "determinism": 9 },
-      "contextWindow": 1000000,
-      "maxOutput": 128000,
-      "releasedAt": "2026-04-16",
       "status": "stable",
       "rollout": { "channel": "stable", "status": "stable", "lane": "default" },
       "constraints": { "supportsTemperature": false, "supportsTopP": false, "supportsAdaptiveThinking": true }

--- a/scripts/models/release-watch.json
+++ b/scripts/models/release-watch.json
@@ -2,6 +2,15 @@
   "schemaVersion": 1,
   "watchedReleases": [
     {
+      "id": "anthropic-claude-opus-5-2026-07-24",
+      "provider": "anthropic",
+      "modelId": "claude-opus-5",
+      "label": "Claude Opus 5",
+      "announcedAt": "2026-07-24",
+      "sourceUrl": "https://www.anthropic.com/news/claude-opus-5",
+      "notifyUntil": "curated"
+    },
+    {
       "id": "anthropic-claude-opus-4-8-2026-05-28",
       "provider": "anthropic",
       "modelId": "claude-opus-4-8",

--- a/src/ai/certification/anthropicCertification.test.ts
+++ b/src/ai/certification/anthropicCertification.test.ts
@@ -32,8 +32,12 @@ type CertificationReport = {
     cases: CertificationCaseResult[];
 };
 
-const PINNED_ANTHROPIC_POLICY = { type: 'pinned', pinnedAlias: 'claude-opus-4.7' } as const;
-const MODEL_ID = 'claude-opus-4-7';
+// Certification targets the current Anthropic depth model. Re-run live
+// (RT_ANTHROPIC_API_KEY + RT_USE_LIVE_OBSIDIAN_REQUEST=1) after any Opus
+// promotion — the recorded report in docs/audits/ still reflects the last
+// live run's model until then.
+const PINNED_ANTHROPIC_POLICY = { type: 'pinned', pinnedAlias: 'claude-opus-5' } as const;
+const MODEL_ID = 'claude-opus-5';
 const UNIQUE_CODE = 'AURORA-LATTICE';
 const REPORT_JSON_PATH = resolve(process.cwd(), 'docs', 'audits', 'anthropic-certification.json');
 const REPORT_MD_PATH = resolve(process.cwd(), 'docs', 'audits', 'anthropic-certification.md');

--- a/src/ai/cost/providerPricing.ts
+++ b/src/ai/cost/providerPricing.ts
@@ -55,15 +55,17 @@ export interface ResolvedProviderModelPricing {
 
 export const BUILTIN_PRICING: ProviderPricingTable = {
     anthropic: {
-        'claude-opus-4-8': {
+        // Drop-in upgrade at Opus 4.8 pricing: $5/$25 per MTok; cache write
+        // 1.25× (5m) / 2× (1h), cache read 0.1× — multipliers unchanged.
+        'claude-opus-5': {
             inputPer1M: 5.0,
             outputPer1M: 25.0,
             cacheWrite5mPer1M: 6.25,
             cacheWrite1hPer1M: 10.0,
             cacheReadPer1M: 0.5
         },
-        // Continuity model (one generation back). Same pricing as 4.8.
-        'claude-opus-4-7': {
+        // Continuity model (one generation back). Same pricing as Opus 5.
+        'claude-opus-4-8': {
             inputPer1M: 5.0,
             outputPer1M: 25.0,
             cacheWrite5mPer1M: 6.25,

--- a/src/ai/registry/builtinModels.test.ts
+++ b/src/ai/registry/builtinModels.test.ts
@@ -44,7 +44,33 @@ describe('BUILTIN_MODELS — OpenAI GPT-5.5', () => {
     });
 });
 
-describe('BUILTIN_MODELS — Anthropic Claude Opus 4.8', () => {
+describe('BUILTIN_MODELS — Anthropic Claude Opus 5', () => {
+    it('exposes a 1M context / 128k output window on the stable channel', () => {
+        const model = byAlias('claude-opus-5');
+        expect(model.id).toBe('claude-opus-5');
+        expect(model.line).toBe('claude-opus');
+        expect(model.contextWindow).toBe(1000000);
+        expect(model.maxOutput).toBe(128000);
+        expect(model.status).toBe('stable');
+        expect(model.tier).toBe('DEEP');
+        expect(model.rollout?.channel).toBe('stable');
+    });
+
+    it('captures the Opus 5 request-shape constraints (managed sampling, adaptive-only, thinking on by default)', () => {
+        const model = byAlias('claude-opus-5');
+        expect(model.constraints).toMatchObject({
+            supportsTemperature: false,
+            supportsTopP: false,
+            supportsAdaptiveThinking: true,
+            thinkingDefaultsOn: true
+        });
+        // Opus 5 is configurable-thinking, NOT always-on: the forced-tool
+        // structured path stays valid (with an explicit disabled shape).
+        expect(model.constraints?.thinkingAlwaysOn).toBeUndefined();
+    });
+});
+
+describe('BUILTIN_MODELS — Anthropic Claude Opus 4.8 (continuity)', () => {
     it('exposes a 1M context / 128k output window', () => {
         const model = byAlias('claude-opus-4.8');
         expect(model.id).toBe('claude-opus-4-8');
@@ -102,7 +128,7 @@ describe('BUILTIN_MODELS — Google Gemini', () => {
 describe('BUILTIN_MODELS — catalog policy invariants', () => {
     it('keeps the catalog small enough to be deliberately curated (one top model per provider, plus deliberate splits)', () => {
         const cloud = BUILTIN_MODELS.filter(m => m.provider !== 'none' && m.provider !== 'ollama');
-        // Anthropic 3 (Opus 4.8 + 4.7 continuity + Fable 5 premium pro lane)
+        // Anthropic 3 (Opus 5 + 4.8 continuity + Fable 5 premium pro lane)
         // + OpenAI 2 (5.5 + 5.4 economy) + Google 2 (3.1 Pro depth / 3.5 Flash
         // speed) = 7 cloud models. Fable 5 was promoted under the deliberate
         // process in docs/engineering/standards/model-promotion.md as an

--- a/src/ai/registry/builtinModels.ts
+++ b/src/ai/registry/builtinModels.ts
@@ -19,6 +19,62 @@ const LOCAL_CAPS: Capability[] = ['jsonStrict'];
  */
 export const BUILTIN_MODELS: ModelInfo[] = [
     {
+        // Current Anthropic depth model. Same pricing and feature set as
+        // Opus 4.8 ($5/$25 per MTok, 1M context, 128K output) with two
+        // request-contract deltas, both encoded in constraints:
+        //   - Thinking is ON BY DEFAULT when the `thinking` field is omitted
+        //     (opposite of 4.8, where omission meant no thinking). RT's
+        //     non-thinking paths therefore send an explicit
+        //     thinking:{type:'disabled'} — see thinkingDefaultsOn and the
+        //     adapter note in anthropicApi.ts. Disabled is accepted only at
+        //     effort `high` or below (400 at xhigh/max); RT never emits
+        //     effort above 'high'.
+        //   - temperature/top_p remain rejected (same as 4.7/4.8); adaptive
+        //     thinking is the only on-mode (thinking:{type:'enabled'} → 400).
+        // Cache: 5m/1h TTLs and write/read multipliers unchanged from 4.8;
+        // minimum cacheable prefix drops to 512 tokens (4.8: 1024), so
+        // existing cache_control plumbing carries over and shorter prefixes
+        // now cache. Opus 5 draws from its own rate-limit bucket, separate
+        // from the combined Opus 4.x pool.
+        // PENDING VERIFICATION: contract transcribed from Anthropic's
+        // migration guide (2026-07); run
+        //   npm run smoke-model -- --provider anthropic --model claude-opus-5
+        // before first release with this catalog (needs ANTHROPIC_API_KEY).
+        provider: 'anthropic',
+        id: 'claude-opus-5',
+        alias: 'claude-opus-5',
+        label: 'Claude Opus 5',
+        line: 'claude-opus',
+        tier: 'DEEP',
+        capabilities: [...DEEP_CAPS],
+        personality: { reasoning: 10, writing: 10, determinism: 9 },
+        contextWindow: 1000000,
+        maxOutput: 128000,
+        releasedAt: '2026-07-24',
+        status: 'stable',
+        rollout: {
+            channel: 'stable',
+            status: 'stable',
+            lane: 'default'
+        },
+        constraints: {
+            supportsTemperature: false,
+            supportsTopP: false,
+            supportsAdaptiveThinking: true,
+            thinkingDefaultsOn: true
+        }
+    },
+    {
+        // Continuity model: the immediately-prior Opus, kept one generation
+        // back so authors mid-project aren't force-migrated off 4.8 when
+        // Opus 5 ships. Auto-selection (latest-stable) resolves to Opus 5 —
+        // 4.8 is an explicit opt-in in the picker. Same pricing as Opus 5.
+        // Retire when a newer Opus promotes Opus 5 to N-1.
+        // Opus 4.7+ (incl. 4.8) reject request-level temperature/top_p
+        // (provider-managed sampling) and use adaptive thinking only — the
+        // legacy thinking:{type:'enabled'} shape returns 400. Verified via
+        // smoke probe against Opus 4.7 (2026-05-23); 4.8 keeps the contract
+        // per the migration guide (no breaking changes from 4.7).
         provider: 'anthropic',
         id: 'claude-opus-4-8',
         alias: 'claude-opus-4.8',
@@ -30,40 +86,6 @@ export const BUILTIN_MODELS: ModelInfo[] = [
         contextWindow: 1000000,
         maxOutput: 128000,
         releasedAt: '2026-05-28',
-        status: 'stable',
-        rollout: {
-            channel: 'stable',
-            status: 'stable',
-            lane: 'default'
-        },
-        // Opus 4.7+ (incl. 4.8) reject request-level temperature/top_p
-        // (provider-managed sampling) and use adaptive thinking only — the
-        // legacy thinking:{type:'enabled'} shape returns 400. Verified via
-        // smoke probe against Opus 4.7 (2026-05-23); 4.8 keeps the contract
-        // per the migration guide (no breaking changes from 4.7).
-        constraints: {
-            supportsTemperature: false,
-            supportsTopP: false,
-            supportsAdaptiveThinking: true
-        }
-    },
-    {
-        // Continuity model: the immediately-prior Opus, kept one generation
-        // back so authors mid-project aren't force-migrated off 4.7 when 4.8
-        // ships. Auto-selection (latest-stable) still resolves to 4.8 — 4.7
-        // is an explicit opt-in in the picker. Same request contract and
-        // pricing as 4.8. Retire when a newer Opus promotes 4.8 to N-1.
-        provider: 'anthropic',
-        id: 'claude-opus-4-7',
-        alias: 'claude-opus-4.7',
-        label: 'Claude Opus 4.7',
-        line: 'claude-opus',
-        tier: 'DEEP',
-        capabilities: [...DEEP_CAPS],
-        personality: { reasoning: 10, writing: 10, determinism: 9 },
-        contextWindow: 1000000,
-        maxOutput: 128000,
-        releasedAt: '2026-04-16',
         status: 'stable',
         rollout: {
             channel: 'stable',

--- a/src/ai/registry/modelRequestProfiles.ts
+++ b/src/ai/registry/modelRequestProfiles.ts
@@ -19,6 +19,14 @@ export interface ModelRequestProfile {
      * structured output uses output_config.format instead of a forced tool.
      */
     thinkingAlwaysOn?: boolean;
+    /**
+     * Thinking defaults ON when the `thinking` field is omitted (Claude
+     * Opus 5) but remains configurable — the adapter emits an explicit
+     * thinking:{type:'disabled'} on non-thinking paths to preserve the
+     * Opus 4.8 request contract (thinking off for structured output and
+     * budget-less prose).
+     */
+    thinkingDefaultsOn?: boolean;
 }
 
 const PROVIDER_DEFAULTS: Record<Exclude<AIProviderId, 'none'>, ModelRequestProfile> = {
@@ -80,6 +88,7 @@ function constraintsToProfileOverride(constraints: ModelInfo['constraints']): Pa
     if (constraints.preferredOpenAiEndpoint !== undefined) override.preferredOpenAiEndpoint = constraints.preferredOpenAiEndpoint;
     if (constraints.supportsAdaptiveThinking !== undefined) override.supportsAdaptiveThinking = constraints.supportsAdaptiveThinking;
     if (constraints.thinkingAlwaysOn !== undefined) override.thinkingAlwaysOn = constraints.thinkingAlwaysOn;
+    if (constraints.thinkingDefaultsOn !== undefined) override.thinkingDefaultsOn = constraints.thinkingDefaultsOn;
     return override;
 }
 
@@ -154,4 +163,17 @@ export function modelUsesAlwaysOnThinking(
     modelId?: string
 ): boolean {
     return getModelRequestProfile(provider, modelId).thinkingAlwaysOn === true;
+}
+
+/**
+ * Whether thinking runs by default when the `thinking` field is omitted
+ * (Claude Opus 5). On such models the adapter must send an explicit
+ * thinking:{type:'disabled'} wherever RT expects a non-thinking request.
+ * Declared per-model via ModelInfo.constraints.thinkingDefaultsOn.
+ */
+export function modelThinkingDefaultsOn(
+    provider: Exclude<AIProviderId, 'none'>,
+    modelId?: string
+): boolean {
+    return getModelRequestProfile(provider, modelId).thinkingDefaultsOn === true;
 }

--- a/src/ai/registry/releaseChannels.test.ts
+++ b/src/ai/registry/releaseChannels.test.ts
@@ -27,16 +27,16 @@ describe('release channel curation', () => {
     it('returns the current Anthropic model, the premium pro entry, and the one-back continuity model', () => {
         const picker = getPickerModelsForProvider(BUILTIN_MODELS, 'anthropic').map(model => model.alias);
         // Curated order is [newest-stable, newest-pro], then remainder:
-        //   - 4.8: newest stable, the auto-selected default, offered first.
+        //   - Opus 5: newest stable, the auto-selected default, offered first.
         //   - Fable 5: the 'pro'-channel premium model — visible and pinnable
         //     but never the silent default (it is 2× Opus cost).
-        //   - 4.7: continuity opt-in so in-flight authors aren't force-migrated.
-        expect(picker).toEqual(['claude-opus-4.8', 'claude-fable-5', 'claude-opus-4.7']);
+        //   - 4.8: continuity opt-in so in-flight authors aren't force-migrated.
+        expect(picker).toEqual(['claude-opus-5', 'claude-fable-5', 'claude-opus-4.8']);
     });
 
-    it('keeps Claude Fable 5 off the stable channel so latest-stable stays Opus 4.8', () => {
+    it('keeps Claude Fable 5 off the stable channel so latest-stable stays Opus 5', () => {
         const stable = selectLatestModelByReleaseChannel(BUILTIN_MODELS, 'anthropic', 'stable');
-        expect(stable?.alias).toBe('claude-opus-4.8');
+        expect(stable?.alias).toBe('claude-opus-5');
         const fable = BUILTIN_MODELS.find(model => model.id === 'claude-fable-5');
         expect(fable?.rollout?.channel).toBe('pro');
     });
@@ -49,8 +49,8 @@ describe('release channel curation', () => {
         expect(stable?.alias).toBe('gpt-5.5');
     });
 
-    it('selectLatestModelByReleaseChannel returns the only stable Anthropic model', () => {
+    it('selectLatestModelByReleaseChannel returns the newest stable Anthropic model', () => {
         const stable = selectLatestModelByReleaseChannel(BUILTIN_MODELS, 'anthropic', 'stable');
-        expect(stable?.alias).toBe('claude-opus-4.8');
+        expect(stable?.alias).toBe('claude-opus-5');
     });
 });

--- a/src/ai/router/selectModel.test.ts
+++ b/src/ai/router/selectModel.test.ts
@@ -29,13 +29,13 @@ describe('selectModel', () => {
             policy: { type: 'latestStable' },
             requiredCapabilities: ['longContext', 'jsonStrict', 'reasoningStrong']
         });
-        expect(result.model.alias).toBe('claude-opus-4.8');
+        expect(result.model.alias).toBe('claude-opus-5');
     });
 
-    it('does NOT auto-default to Claude Fable 5 despite its newer releasedAt (2× Opus cost — explicit choice only)', () => {
-        // Fable 5 is newer than Opus 4.8 but sits on the 'pro' rollout channel,
-        // so latest-stable resolution (which reads channel === 'stable') must
-        // keep resolving to Opus 4.8 for every capability-based feature
+    it('does NOT auto-default to Claude Fable 5 (2× Opus cost — explicit choice only)', () => {
+        // Fable 5 sits on the 'pro' rollout channel, so latest-stable
+        // resolution (which reads channel === 'stable') must keep resolving
+        // to Opus 5 for every capability-based feature
         // (Pulse/Gossamer/Inquiry). This is the cost guard: Fable costs 2× Opus.
         const fable = BUILTIN_MODELS.find(m => m.id === 'claude-fable-5');
         expect(fable, 'Claude Fable 5 must be in the registry').toBeTruthy();
@@ -47,7 +47,7 @@ describe('selectModel', () => {
             policy: { type: 'latestStable' },
             requiredCapabilities: [...deepCaps]
         });
-        expect(result.model.alias).toBe('claude-opus-4.8');
+        expect(result.model.alias).toBe('claude-opus-5');
         expect(result.model.id).not.toBe('claude-fable-5');
     });
 

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -91,6 +91,18 @@ export interface ModelInfo {
          * `thinking:{type:'adaptive'}` field); an always-on model emits none.
          */
         thinkingAlwaysOn?: boolean;
+        /**
+         * Thinking runs by default when the `thinking` field is omitted
+         * (Claude Opus 5). Unlike `thinkingAlwaysOn`, thinking IS
+         * configurable: `thinking:{type:'disabled'}` is accepted at effort
+         * `high` or below (400 at xhigh/max). The adapter must therefore emit
+         * an explicit `thinking:{type:'disabled'}` on every path where RT
+         * relies on thinking being off (structured output via forced tool,
+         * plain prose without a thinking budget) — silently omitting the
+         * field would run adaptive thinking inside max_tokens and change the
+         * request contract vs Opus 4.8.
+         */
+        thinkingDefaultsOn?: boolean;
         /** Provider endpoint/lane RT should use for this model. */
         preferredOpenAiEndpoint?: 'responses' | 'chat_completions';
     };

--- a/src/api/anthropicApi.test.ts
+++ b/src/api/anthropicApi.test.ts
@@ -63,14 +63,14 @@ describe('anthropic token counting', () => {
 
         const result = await countAnthropicTokens(
             'test-key',
-            'claude-opus-4-7',
+            'claude-opus-4-8',
             'System rules',
             'User prompt body'
         );
 
         expect(result).toEqual({
             provider: 'anthropic',
-            modelId: 'claude-opus-4-7',
+            modelId: 'claude-opus-4-8',
             inputTokens: 4321,
             source: 'provider_count'
         });
@@ -84,7 +84,7 @@ describe('anthropic token counting', () => {
 
         expect(request.url).toBe('https://api.anthropic.com/v1/messages/count_tokens');
         expect(request.headers?.['anthropic-version']).toBe('2023-06-01');
-        expect(body.model).toBe('claude-opus-4-7');
+        expect(body.model).toBe('claude-opus-4-8');
         expect(body.system).toEqual([{ type: 'text', text: 'System rules' }]);
         expect(body.messages?.[0]?.role).toBe('user');
         expect(body.messages?.[0]?.content?.[0]).toEqual({ type: 'text', text: 'User prompt body' });
@@ -101,7 +101,7 @@ describe('anthropic token counting', () => {
 
         await countAnthropicTokens(
             'test-key',
-            'claude-opus-4-7',
+            'claude-opus-4-8',
             'System rules',
             'Return {"answer":"ACK"}.',
             false,
@@ -154,7 +154,7 @@ describe('anthropic token counting', () => {
 
         await countAnthropicTokens(
             'test-key',
-            'claude-opus-4-7',
+            'claude-opus-4-8',
             'System rules',
             'Return JSON per the schema in the prompt.',
             true,
@@ -186,7 +186,7 @@ describe('anthropic token counting', () => {
     it('rejects token count responses that omit input_tokens', () => {
         expect(normalizeAnthropicTokenCountResponse({
             total_tokens: 987
-        }, 'claude-opus-4-7')).toBeNull();
+        }, 'claude-opus-4-8')).toBeNull();
     });
 });
 
@@ -332,6 +332,90 @@ describe('Claude Fable 5 always-on-thinking request shape', () => {
 
         const result = await callAnthropicApi('test-key', 'claude-fable-5', null, 'Hi', 4000, true);
         expect(result.error).not.toContain('zero data retention');
+    });
+});
+
+describe('Claude Opus 5 thinking-defaults-on request shape', () => {
+    const SCHEMA = {
+        type: 'object',
+        properties: { answer: { type: 'string' } },
+        required: ['answer'],
+        additionalProperties: false
+    };
+
+    beforeEach(() => {
+        mockedRequestUrl.mockReset();
+    });
+
+    it('keeps the forced tool + tool_choice structured path but explicitly disables thinking', async () => {
+        // Opus 5 runs adaptive thinking when the `thinking` field is omitted —
+        // the opposite of 4.8. The forced-tool structured path depends on
+        // thinking being off, so the adapter must emit thinking:{type:'disabled'}
+        // (accepted at the default effort `high`) instead of omitting the field.
+        mockedRequestUrl.mockResolvedValue({
+            status: 200,
+            text: '',
+            json: {
+                content: [{ type: 'tool_use', name: 'record_structured_response', input: { answer: 'ACK' } }],
+                stop_reason: 'tool_use'
+            }
+        } as never);
+
+        await callAnthropicApi(
+            'test-key',
+            'claude-opus-5',
+            'System rules',
+            'Return JSON.',
+            4000,
+            true,
+            undefined,
+            undefined,
+            8192,
+            false,
+            undefined,
+            SCHEMA
+        );
+
+        const body = lastRequestBody();
+        expect(body.tool_choice).toEqual({ type: 'tool', name: 'record_structured_response' });
+        expect(body.output_config).toBeUndefined();
+        expect(body.thinking).toEqual({ type: 'disabled' });
+        // No thinking headroom on the structured path — thinking is off.
+        expect(body.max_tokens).toBe(4000);
+    });
+
+    it('explicitly disables thinking on budget-less prose requests', async () => {
+        mockTextResponse('done', { stop_reason: 'end_turn' });
+
+        await callAnthropicApi('test-key', 'claude-opus-5', null, 'Hi', 4000, true);
+
+        const body = lastRequestBody();
+        expect(body.thinking).toEqual({ type: 'disabled' });
+        expect(body.output_config).toBeUndefined();
+        expect(body.max_tokens).toBe(4000);
+    });
+
+    it('uses adaptive thinking + effort when a thinking budget is requested', async () => {
+        mockTextResponse('done', { stop_reason: 'end_turn' });
+
+        await callAnthropicApi(
+            'test-key',
+            'claude-opus-5',
+            'System rules',
+            'Think it through.',
+            4000,
+            true,
+            undefined,
+            undefined,
+            8192
+        );
+
+        const body = lastRequestBody();
+        expect(body.thinking).toEqual({ type: 'adaptive' });
+        expect(body.output_config?.effort).toBe('high');
+        expect(body.max_tokens).toBe(4000 + 8192);
+        expect(body.temperature).toBeUndefined();
+        expect(body.top_p).toBeUndefined();
     });
 });
 

--- a/src/api/anthropicApi.ts
+++ b/src/api/anthropicApi.ts
@@ -7,7 +7,7 @@
 import { requestUrl } from 'obsidian';
 import { warnLegacyAccess } from './legacyAccessGuard';
 import { CACHE_BREAK_DELIMITER } from '../ai/prompts/composeEnvelope';
-import { modelSupportsAdaptiveThinking, modelUsesAlwaysOnThinking } from '../ai/registry/modelRequestProfiles';
+import { modelSupportsAdaptiveThinking, modelThinkingDefaultsOn, modelUsesAlwaysOnThinking } from '../ai/registry/modelRequestProfiles';
 import type { AnthropicCacheTtl, EvidenceDocument, TokenCountResult } from '../ai/types';
 
 export type AnthropicTextBlock = {
@@ -140,7 +140,8 @@ type AnthropicMessageRequestBody = {
   top_p?: number;
   thinking?:
     | { type: 'enabled'; budget_tokens: number }
-    | { type: 'adaptive' };
+    | { type: 'adaptive' }
+    | { type: 'disabled' };
   output_config?: {
     effort?: 'low' | 'medium' | 'high';
     format?: { type: 'json_schema'; schema: Record<string, unknown> };
@@ -465,6 +466,20 @@ function buildAnthropicMessageRequestBody(
     } else {
       requestBody.thinking = { type: 'enabled', budget_tokens: thinkingBudget };
     }
+  } else if (modelThinkingDefaultsOn('anthropic', input.modelId)) {
+    // Claude Opus 5: omitting `thinking` runs ADAPTIVE thinking by default —
+    // the opposite of Opus 4.8/4.7, where omission meant no thinking. RT's
+    // non-thinking paths (forced-tool structured output, budget-less prose)
+    // depend on thinking being off: thinking spends inside max_tokens (we add
+    // no headroom here), and the forced tool_choice structured path was only
+    // ever validated against non-thinking requests. Emit the explicit
+    // disabled shape to preserve the Opus 4.8 contract. Per Anthropic docs,
+    // thinking:{type:'disabled'} is accepted at effort `high` or below and
+    // 400s at xhigh/max — safe here because these paths never emit
+    // output_config.effort (the API default is `high`). mapBudgetToEffort
+    // caps at 'high', so the thinking-enabled branch can never collide with
+    // that constraint either.
+    requestBody.thinking = { type: 'disabled' };
   }
   return requestBody;
 }

--- a/src/constants/aiDefaults.ts
+++ b/src/constants/aiDefaults.ts
@@ -3,4 +3,4 @@
 
 export const DEFAULT_GOOGLE_MODEL_ID = 'gemini-3.5-flash';
 export const DEFAULT_OPENAI_MODEL_ID = 'gpt-5.5';
-export const DEFAULT_ANTHROPIC_MODEL_ID = 'claude-opus-4-8';
+export const DEFAULT_ANTHROPIC_MODEL_ID = 'claude-opus-5';

--- a/src/inquiry/services/inquiryModelResolver.test.ts
+++ b/src/inquiry/services/inquiryModelResolver.test.ts
@@ -4,7 +4,7 @@ import { buildDefaultAiSettings } from '../../ai/settings/aiSettings';
 import { resolveInquiryEngine } from './inquiryModelResolver';
 
 describe('resolveInquiryEngine', () => {
-    it('keeps Anthropic Auto on Sonnet 4.6 when the provider uses latestStable', () => {
+    it('resolves Anthropic latestStable to the current Opus', () => {
         const plugin = {
             settings: {
                 aiSettings: {
@@ -24,11 +24,11 @@ describe('resolveInquiryEngine', () => {
 
         expect(resolved.provider).toBe('anthropic');
         expect(resolved.blocked).toBeUndefined();
-        expect(resolved.modelId).toBe('claude-opus-4-8');
-        expect(resolved.modelAlias).toBe('claude-opus-4.8');
+        expect(resolved.modelId).toBe('claude-opus-5');
+        expect(resolved.modelAlias).toBe('claude-opus-5');
     });
 
-    it('resolves pinned Anthropic Opus 4.7 when explicitly selected', () => {
+    it('resolves pinned Anthropic Opus 4.8 (continuity) when explicitly selected', () => {
         const plugin = {
             settings: {
                 aiSettings: {


### PR DESCRIPTION
Promotes **Claude Opus 5** (`claude-opus-5`, released 2026-07-24) to the current Anthropic depth model per `docs/engineering/standards/model-promotion.md`: Opus 4.8 moves to the one-back continuity slot, Opus 4.7 retires (N-2) in the same change.

## Why promote

- Drop-in upgrade at identical pricing: **$5/$25 per MTok**, cache write $6.25 (5m) / $10 (1h), cache read $0.50 — multipliers unchanged from 4.8.
- Same 1M context / 128K output window; full effort ladder (`low`–`max`), adaptive-only thinking — confirmed by the daily models snapshot (`scripts/models/latest-models.json`) and release-watch, which flagged it as Anthropic's newest model.
- Anthropic positions it as a step-change over 4.8 on deep reasoning and long-horizon work — the exact profile of RT's Anthropic depth lane (Inquiry/Gossamer/Pulse).

## Request-contract delta (the load-bearing change)

Opus 5 runs **adaptive thinking by default when the `thinking` field is omitted** — the opposite of 4.8/4.7, where omission meant no thinking. RT's non-thinking paths (forced-tool structured output, budget-less prose) depended on omission meaning off; silently carrying that forward would have run thinking inside `max_tokens` (truncation risk) and paired active thinking with a forced `tool_choice` (unvalidated combination).

Encoded as a new declared constraint, `thinkingDefaultsOn` (never pattern-matched on the id):

- `src/api/anthropicApi.ts` now emits an explicit `thinking: {type: 'disabled'}` on every non-thinking path for such models. Per Anthropic docs this is accepted at effort `high` or below; RT never emits effort above `high` (`mapBudgetToEffort` caps there), so the combination can't 400.
- Thinking-budget requests keep the existing adaptive path (`thinking: {type:'adaptive'}` + `output_config.effort`).
- `temperature`/`top_p` remain rejected and stripped (same as 4.7/4.8).

## Cache support

- TTLs (5m/1h), write/read multipliers, and all existing `cache_control` plumbing carry over unchanged.
- Minimum cacheable prefix drops **1024 → 512 tokens**, so shorter prefixes now cache (no code change needed).
- Note for rollout: Opus 5 draws from its own rate-limit bucket, separate from the combined Opus 4.x pool.

## Lockstep updates (per `ai-model-curation.md`)

- `src/ai/registry/builtinModels.ts` — Opus 5 in (stable/default lane), 4.8 → continuity, 4.7 removed
- `src/ai/cost/providerPricing.ts` + `scripts/models/pricing.json` — pricing rows swapped
- `scripts/models/registry.json` — drift snapshot mirrored
- `scripts/models/release-watch.json` — Opus 5 watch entry added
- `src/constants/aiDefaults.ts` — `DEFAULT_ANTHROPIC_MODEL_ID` → `claude-opus-5`
- `src/ai/types.ts` / `modelRequestProfiles.ts` — `thinkingDefaultsOn` constraint + profile projection
- Tests: new Opus 5 request-shape suite (forced tool + explicit disabled thinking; adaptive path; max_tokens semantics), latest-stable pins updated, 4.7 fixtures repointed to 4.8, certification target moved to `claude-opus-5`
- `docs/engineering/standards/model-promotion.md` — catalog-shape block refreshed

Users pinned to `claude-opus-4.7` fall back to latestStable with a settings-validation warning (existing behavior, no migration needed).

## Verification

- `npx tsc --noEmit` clean
- `npm run gates` — **all 13 gates pass** (incl. model coverage, AI model drift, catalog dispatch contract)
- `npx vitest run` — 2818 passed / 2 skipped
- ⚠️ **Pending manual step:** the live smoke probe (`npm run smoke-model -- --provider anthropic --model claude-opus-5`) could not run here — no `ANTHROPIC_API_KEY` in this environment. The registry entry carries a `PENDING VERIFICATION` note; per curation policy, run the smoke (and exercise one real corpus) before first release with this catalog and before clearing release-watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KH4qgCtChHPgS3XG4fxVNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH4qgCtChHPgS3XG4fxVNM)_