### PR TITLE
fix(ai): resolve lint-ratchet CI failure + add pre-push gate

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run lint:obsidian

--- a/src/ai/settings/validateAiSettings.ts
+++ b/src/ai/settings/validateAiSettings.ts
@@ -160,8 +160,8 @@ export function validateAiSettings(input?: AiSettingsV1 | null): AiSettingsValid
         const seen = new Set<DeclarableLocalCapability>();
         const unknown: string[] = [];
         for (const entry of value.localLlm.declaredCapabilities) {
-            if (DECLARABLE_LOCAL_CAPABILITIES.includes(entry as DeclarableLocalCapability)) {
-                seen.add(entry as DeclarableLocalCapability);
+            if (DECLARABLE_LOCAL_CAPABILITIES.includes(entry)) {
+                seen.add(entry);
             } else {
                 unknown.push(String(entry));
             }


### PR DESCRIPTION
## Summary

`main`'s Quality Gate CI has been failing since commit `2c37962` ("feat(ai): let authors declare local model capabilities", ~16h ago) — two unnecessary `as DeclarableLocalCapability` casts in `src/ai/settings/validateAiSettings.ts` tripped the enforced Obsidian lint ratchet's `@typescript-eslint/no-unnecessary-type-assertion` rule (baseline 0 → 2). A later commit (`c0610d7`) landed on top without fixing it, so `main` stayed red.

- `src/ai/settings/validateAiSettings.ts` — drop the two redundant casts in the `declaredCapabilities` normalization loop. `value.localLlm.declaredCapabilities` is already typed `DeclarableLocalCapability[]`, confirmed against `src/ai/types.ts`.
- `.husky/pre-push` (new) — runs `npm run lint:obsidian`, the exact same ratchet check CI runs. **Root cause of why this slipped through:** the pre-commit hook only runs `code-quality-check.mjs` (a separate regex-based scanner with no ESLint involvement), and `npm run build`/`gates` never invoke `lint:obsidian` either — it was previously wired into CI and the `prerelease` script only. A ratchet regression could pass every local check and still turn `main`'s CI red on push. This hook closes that gap.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint:obsidian` — PASS, ratchet back to baseline (0 delta on all 5 enforced rules)
- [x] `npx vitest run` — full suite, 3038 passed / 2 pre-existing skips, 0 failures
- [x] Verified live: `git push` on this branch triggered the new pre-push hook, which ran the ratchet check and passed before the push completed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012bbb8emgKrHyTqW9kL14rf

---
_Generated by [Claude Code](https://claude.ai/code/session_012bbb8emgKrHyTqW9kL14rf)_